### PR TITLE
fix: clickCatcher has a wrong size and position when using windowed mode

### DIFF
--- a/Debugger/GUIWindow.cs
+++ b/Debugger/GUIWindow.cs
@@ -121,8 +121,11 @@ namespace ModTools
                 return;
             }
 
-            clickCatcher.absolutePosition = rect.position;
-            clickCatcher.size = new Vector2(rect.width, rect.height);
+            //adjust rect from unity pixels to C:S pixels via GetUIView().ratio
+            var ratio = UIView.GetAView().ratio;
+
+            clickCatcher.absolutePosition = new Vector3(rect.position.x * ratio, rect.position.y * ratio);
+            clickCatcher.size = new Vector2(rect.width * ratio, rect.height * ratio);
             clickCatcher.isVisible = visible;
             clickCatcher.zOrder = int.MaxValue;
         }


### PR DESCRIPTION
When C:S runs in windowed mode it still uses the fullscreen resolution as size of the game window. For example I'm playing in windowed mode with 1600x900, but C:S uses still 1920x1080 for GUI positions. That's best observable via Sapphire & Pause Menu: the background "ModalEffect" is still 1920x1080. but it's also easy to see with other controls or via ModTools (UIView.fixedHeight, UiView.fixedWidth and some other places).
Unity doesn't use the C:S coordinate system, but instead uses the real pixels. Therefore the coordinate systems of Unity and C:S do not match. As a result a click catcher UIPanel does not match its corresponding Mod Tools window (neither size nor position). That's easy to see in this image: https://i.imgur.com/iFzRHzN.jpg : The click catcher is highlighted in green (via Sapphire).
To match the two coordinate systems, there's a ratio property in UIView. Using this property it's just simple multiplications to convert a Unity position/size to C:S position/size.
