### PR TITLE
Change notification message color to cyan

### DIFF
--- a/Debugger/Console.cs
+++ b/Debugger/Console.cs
@@ -387,7 +387,7 @@ namespace ModTools
             {
                 GUILayout.BeginHorizontal(skin.box);
 
-                GUI.contentColor = Color.blue;
+                GUI.contentColor = Color.cyan;
                 GUILayout.Label(item.Value);
                 GUI.contentColor = Color.white;
 


### PR DESCRIPTION
Simply changes the color of notification-class console mesages from blue to cyan. Blue is unreadable against the black background; cyan is better.

Before:

![Console notifications with blue text](https://i.imgur.com/EJiD1LW.png)

After:

![Console notifications with cyan text](https://i.imgur.com/VNqeYYp.png)

Tested the change by compiling the repository with Visual Studio 2017 and loading on Cities: Skylines 1.9.0-f5, Windows 10.

Thank you for this mod, by the way. I'm looking to improve the map editor and this mod will be a serious help.